### PR TITLE
Delete author#7

### DIFF
--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -2,4 +2,14 @@ class AuthorsController < ApplicationController
   def show
     @author = Author.find(params[:id])
   end
+  
+  def destroy
+    author = Author.find(params[:id])
+    books = author.books
+    books.each do |book|
+      Book.destroy(book.id)
+    end
+    Author.destroy(params[:id])
+    redirect_to books_path
+  end
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,6 +1,6 @@
 class Author < ApplicationRecord
   validates_presence_of :name
   validates_uniqueness_of :name
-  has_many :book_authors
+  has_many :book_authors, dependent: :destroy
   has_many :books, through: :book_authors
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,7 +1,7 @@
 class Book < ApplicationRecord
   validates_presence_of :title, :pages, :publishing_year
   validates_uniqueness_of :title
-  has_many :book_authors
+  has_many :book_authors, dependent: :destroy
   has_many :authors, through: :book_authors
   has_many :reviews
 end

--- a/app/views/authors/show.html.erb
+++ b/app/views/authors/show.html.erb
@@ -21,3 +21,6 @@
     </div>
   <% end %>
 </div>
+<footer>
+  <%= link_to "Delete Author", author_path(@author), method: :delete %>
+</footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,5 @@ Rails.application.routes.draw do
 
   resources :users, only: [:show]
   
-  resources :authors, only: [:show]
+  resources :authors, only: [:show, :destroy]
 end

--- a/spec/features/user_can_delete_an_author_spec.rb
+++ b/spec/features/user_can_delete_an_author_spec.rb
@@ -27,4 +27,22 @@ describe 'When a user visits an author show page' do
     expect(page).to_not have_content(book.title)
     expect(page).to_not have_content(book_2.title)
   end
+  it 'should delete its own co-authored books but not the co-author' do
+    author = Author.create(name: "author_1")
+    author_2 = Author.create(name: "Author 2")
+    book = author.books.create(title: "Book 1", pages: 1, publishing_year: 2001)
+    book_2 = Book.create(authors: [author, author_2], title: "Book 2", pages: 1, publishing_year: 2001)
+    book_3 = author_2.books.create(title: "Book 3", pages: 1, publishing_year: 2001)
+    
+    visit author_path(author) 
+    
+    click_link "Delete Author" 
+    
+    expect(current_path).to eq(books_path)
+    expect(page).to_not have_content(author.name)
+    expect(page).to_not have_content(book.title)
+    expect(page).to_not have_content(book_2.title)
+    expect(page).to have_content(author_2.name)
+    expect(page).to have_content(book_3.title)
+  end
 end

--- a/spec/features/user_can_delete_an_author_spec.rb
+++ b/spec/features/user_can_delete_an_author_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'When a user visits an author show page' do
+  it 'should see a link to delete the author' do
+    author = Author.create(name: "author_1")
+    book = author.books.create(title: "Book 1", pages: 1, publishing_year: 2001)
+    
+    visit author_path(author) 
+    
+    click_link "Delete Author" 
+    
+    expect(current_path).to eq(books_path)
+    expect(page).to_not have_content(author.name)
+    expect(page).to_not have_content(book.title)
+  end
+end

--- a/spec/features/user_can_delete_an_author_spec.rb
+++ b/spec/features/user_can_delete_an_author_spec.rb
@@ -13,4 +13,18 @@ describe 'When a user visits an author show page' do
     expect(page).to_not have_content(author.name)
     expect(page).to_not have_content(book.title)
   end
+  it 'should delete all books associated with the author' do
+    author = Author.create(name: "author_1")
+    book = author.books.create(title: "Book 1", pages: 1, publishing_year: 2001)
+    book_2 = author.books.create(title: "Book 2", pages: 1, publishing_year: 2001)
+    
+    visit author_path(author) 
+    
+    click_link "Delete Author" 
+    
+    expect(current_path).to eq(books_path)
+    expect(page).to_not have_content(author.name)
+    expect(page).to_not have_content(book.title)
+    expect(page).to_not have_content(book_2.title)
+  end
 end


### PR DESCRIPTION
Closes #7 
User Story 20 Delete an Author
Adds ability to delete an author. Also deletes all the author's books. Deletes any books that the author co-authored, but does not affect the co-authors or their other books. 
Tests passing with 100% coverage.
Driver-navigator'd this build. 